### PR TITLE
Fix NaN handling in contour efficiency plots

### DIFF
--- a/plot_efficiencies.py
+++ b/plot_efficiencies.py
@@ -164,10 +164,20 @@ def plot_total_efficiency_field(df: pd.DataFrame, output_dir="efficiency_fields"
         Z = pivot.values
 
         plt.figure(figsize=(8, 6))
-        # Automatically determine contour levels based on efficiency range
-        min_eff = np.floor(Z.min())
-        max_eff = np.ceil(Z.max())
-        levels = np.arange(min_eff, max_eff + 1, 2)
+        # Automatically determine contour levels based on efficiency range.
+        # NaN values can appear in Z if some speed/pressure combinations are
+        # missing. Using nanmin/nanmax ensures valid ranges are computed even
+        # when NaNs are present.
+        if np.all(~np.isfinite(Z)):
+            # Skip if there are no finite values to contour
+            continue
+
+        min_eff = np.floor(np.nanmin(Z))
+        max_eff = np.ceil(np.nanmax(Z))
+        if max_eff < min_eff:
+            levels = [min_eff]
+        else:
+            levels = np.arange(min_eff, max_eff + 1, 2)
         contour = plt.contourf(X, Y, Z, levels=levels, cmap="inferno", extend='both')
         cbar = plt.colorbar(contour)
         cbar.set_label("Total Efficiency [%]")


### PR DESCRIPTION
## Summary
- ensure contour level range handles NaN values

## Testing
- `python3 plot_efficiencies.py` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_686262dbb1608322abe6886b87f9067f